### PR TITLE
Fix Navigation Container bug for sheets/fullScreen.

### DIFF
--- a/MovieCatalog/Packages/2-Infrastructure/Navigation/Sources/Navigation/Router.swift
+++ b/MovieCatalog/Packages/2-Infrastructure/Navigation/Sources/Navigation/Router.swift
@@ -70,6 +70,7 @@ public extension Router {
     func resignActive() {
         logger.debug("\(self.debugDescription): \(#function)")
         isActive = false
+        parent?.setActive()
     }
 
     static func previewRouter() -> Router {


### PR DESCRIPTION
Fixes #8

When presenting sheets/full screen content, the `NavigationContainer`
won't call `onAppear` again, then the router won't be set to active and
there won't be active routers, which caused navigation failing as
mentioned in #8.

I opted to call `parent?.setActive()` on the child's `resignActive`.

As the `setActive` already takes the parent in consideration when
setting itself active.

This fixes the issue.
 

https://github.com/user-attachments/assets/66ef880f-ef62-4a2c-8d15-7eb34e756f33

